### PR TITLE
Fix missing httpmeth check

### DIFF
--- a/src/prologue/core/application.nim
+++ b/src/prologue/core/application.nim
@@ -7,7 +7,7 @@ from cgi import CgiError
 
 from ./utils import isStaticFile
 from ./route import pattern, initPath, initRePath, newPathHandler, newRouter,
-    newReRouter, DuplicatedRouteError, DuplicatedReveredRouteError, UrlPattern,
+    newReRouter, DuplicatedRouteError, DuplicatedReversedRouteError, UrlPattern,
     add, `[]`, `[]=`, hasKey
 from ./form import parseFormParams
 from ./nativesettings import newSettings, newCtxSettings, getOrDefault, Settings
@@ -95,7 +95,7 @@ proc addRoute*(app: Prologue, route: Regex, handler: HandlerAsync,
 proc addReversedRoute(app: Prologue, name, route: string) {.inline.} =
   if name.len != 0:
     if app.gScope.reversedRouter.hasKey(name):
-      raise newException(DuplicatedReveredRouteError,
+      raise newException(DuplicatedReversedRouteError,
           fmt"Revered Route {name} is duplicated!")
     app.gScope.reversedRouter[name] = route
 

--- a/src/prologue/core/route.nim
+++ b/src/prologue/core/route.nim
@@ -102,6 +102,9 @@ proc findHandler*(ctx: Context): PathHandler =
 
   # find params route
   for route, handler in ctx.gScope.router:
+    if route.httpMethod != rawPath.httpMethod:
+      continue
+
     let routeList = route.route.split("/")
     var flag = true
     if pathList.len == routeList.len:

--- a/src/prologue/core/route.nim
+++ b/src/prologue/core/route.nim
@@ -15,7 +15,7 @@ type
   RouteError* = object of PrologueError
   RouteResetError* = object of RouteError
   DuplicatedRouteError* = object of RouteError
-  DuplicatedReveredRouteError* = object of RouteError
+  DuplicatedReversedRouteError* = object of RouteError
 
   UrlPattern* = tuple
     route: string


### PR DESCRIPTION
this check prevents that a route is callable with any httpmethod. if a route expects only get, it should respond with an 405 (method not allowed). but porologue sent an 200 (ok).