### PR TITLE
updated "hello world" example with fixed newApp args

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ import prologue
 proc hello*(ctx: Context) {.async.} =
   resp "<h1>Hello, Prologue!</h1>"
 
-let app = newApp()
+let settings = newSettings()
+var app = newApp(settings = settings)
+
 app.addRoute("/", hello)
 app.run()
 ```


### PR DESCRIPTION
Added a dummy newSettings as args to the newApp. The existing Hello World example would error out.
This is part of fixing #91