### PR TITLE
fix custom setting error

### DIFF
--- a/src/prologue/core/nativesettings.nim
+++ b/src/prologue/core/nativesettings.nim
@@ -71,8 +71,7 @@ func newSettings*(
                           "appName": appName}})
   else:
     var data = data
-    data["secretKey"] = %* secretKey
-    data["appName"] = %* appName
+    data["prologue"] = %* {"secretKey": secretKey, "appName": appName}
 
     result = Settings(address: address, port: port, debug: debug, 
                   reusePort: reusePort, bufSize: bufSize,


### PR DESCRIPTION
It will break the compiling process if you have custom data for your application settings like this:
```nim
settings = newSettings(..., data = %* {"languages": @["en", "zh_CN"]})
```

See https://github.com/planety/prologue-examples/pull/4