### PR TITLE
fix Example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ import prologue
 proc hello*(ctx: Context) {.async.} =
   resp "<h1>Hello, Prologue!</h1>"
 
-let app = newApp()
+var settings = newSettings()
+let app = newApp(settings)
 app.get("/", hello)
 app.run()
 ```


### PR DESCRIPTION
without this change i get:

```
Error: type mismatch: got <>
but expected one of:
func newApp(settings: Settings; middlewares: openArray[HandlerAsync] = @[];
            startup: openArray[Event] = @[]; shutdown: openArray[Event] = @[];
    errorHandlerTable = newErrorHandlerTable(
    [(Http404, default404Handler), (Http500, default500Handler)]);
            appData = newStringTable(mode = modeCaseSensitive)): Prologue

expression: newApp()
```