### PR TITLE
Allow '%' in urls to allow URL encoded paths

### DIFF
--- a/src/prologue/core/route.nim
+++ b/src/prologue/core/route.nim
@@ -29,7 +29,7 @@ import ./httpexception
 
 const 
   pathSeparator = '/'
-  allowedCharsInUrl = {'a'..'z', 'A'..'Z', '0'..'9', '-', '.', '_', '~', pathSeparator}
+  allowedCharsInUrl = {'a'..'z', 'A'..'Z', '0'..'9', '-', '.', '_', '~', '%', pathSeparator}
   wildcard = '*'
   startParam = '{'
   endParam = '}'


### PR DESCRIPTION
eg:

```javascript

encodeURI("Österreich") # <- Austria
"%C3%96sterreich"

```