### PR TITLE
Added overload for setCookie with a Cookie object (implements #115)

### DIFF
--- a/src/prologue/core/context.nim
+++ b/src/prologue/core/context.nim
@@ -279,6 +279,10 @@ func getCookie*(ctx: Context, key: string, default = ""): string {.inline.} =
   ## value will be returned.
   getCookie(ctx.request, key, default)
 
+proc setCookie*(ctx: Context, cookie: Cookie) =
+  ## Sets Cookie for Response.
+  ctx.response.setCookie(cookie)
+
 proc setCookie*(ctx: Context, key, value: string, expires = "", 
                 maxAge: Option[int] = none(int), domain = "", 
                 path = "", secure = false, httpOnly = false, sameSite = Lax) {.inline.} =

--- a/src/prologue/core/response.nim
+++ b/src/prologue/core/response.nim
@@ -54,13 +54,17 @@ template addHeader*(response: var Response, key, value: string) =
   ## Adds header values to the existing `HttpHeaders`.
   response.headers.add(key, value)
 
+template setCookie*(response: var Response, cookie: Cookie) =
+  ## Sets the cookie of response.
+  response.addHeader("Set-Cookie", $cookie)
+
 template setCookie*(response: var Response, key, value: string, expires = "",
                 maxAge: Option[int] = none(int), domain = "", path = "", secure = false,
                 httpOnly = false, sameSite = Lax) =
   ## Sets the cookie of response.
   let cookies = initCookie(key, value, expires, maxAge, domain, 
                            path, secure, httpOnly, sameSite)
-  response.addHeader("Set-Cookie", $cookies)
+  response.setCookie(cookies)
 
 template setCookie*(response: var Response, key, value: string, expires: DateTime|Time, 
                 maxAge: Option[int] = none(int), domain = "",
@@ -68,7 +72,7 @@ template setCookie*(response: var Response, key, value: string, expires: DateTim
   ## Sets the cookie of response.
   let cookies = initCookie(key, value, expires, maxAge, domain, 
                           path, secure, httpOnly, sameSite)
-  response.addHeader("Set-Cookie", $cookies)
+  response.setCookie(cookies)
 
 template deleteCookie*(response: var Response, key: string, value = "", path = "",
                    domain = "") =


### PR DESCRIPTION
adds overloads for `setCookie(response, cookie: Cookie)` and `setCookie(context, cookie: Cookie)`