### PR TITLE
Fixed markdown issues

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -82,9 +82,9 @@ To do so, just follow these steps:
 
 1. [download](https://www.musl-libc.org/download.html) the tar file
 2. Unpack the tar file somewhere
-3. Run `bash configure` in the unpacked directory. WARNING: Make sure that you do NOT install musl with `--prefix` being  `/usr/local`, as that may adversely affect your system. Use somewhere else where it is unlikely to override files, e.g. `/usr/local/musl`. This path will further be referred to as <MUSL_INSTALL_PATH>
+3. Run `bash configure` in the unpacked directory. WARNING: Make sure that you do NOT install musl with `--prefix` being  `/usr/local`, as that may adversely affect your system. Use somewhere else where it is unlikely to override files, e.g. `/usr/local/musl`. This path will further be referred to as `<MUSL_INSTALL_PATH>`
 4. Run `make && make install` in the unpacked directory
-5. Add <MUSL_INSTALL_PATH> to your PATH environment variable
+5. Add `<MUSL_INSTALL_PATH>` to your PATH environment variable
 6. Validate whether you set everything up correctly by opening a new terminal and seeing whether you have access to the `musl-gcc` binary
 
 #### Compiling your dynamically linked musl binary
@@ -370,17 +370,17 @@ The simplest way is installing the [compiler og the zig programming language](ht
 
 The steps go as follows:
 
-1. Install zig
-2. Write a bashscript called `zigcc`
+- Install zig
+- Write a bashscript called `zigcc`
 
 ```sh
 #!/bin/sh
 zig cc $@
 ```
 
-3. Move `zigcc` to somewhere on your path, e.g. `/usr/local/bin`.
+- Move `zigcc` to somewhere on your path, e.g. `/usr/local/bin`.
 This is required since the nim compiler does not tolerate spaces in commands that call compilers.
-4. Write yourself a bashscript with a command to compile your project. 
+- Write yourself a bashscript with a command to compile your project. 
 This can't be done via nimble tasks since the syntax is not allowed within nimble tasks.
 Replace the "X.XX" with the glibc version that you want as well as the other placeholders.
 
@@ -404,7 +404,7 @@ nim c \
 src/<YOUR_MAIN_FILE>.nim
 ```
 
-5. Run projectCompile.sh
+- Run projectCompile.sh
 
 #### Solution 2: Create a compilation environment
 Instead of using zig, you can set up a second docker container that contains the glibc version you want, gcc, nim, nimble and the C-libs you require. 


### PR DESCRIPTION
This should fix 2 markdown issues:
1) The fact that `<SOMEWORD>` will not be rendered for some reason. I guess it gets interpreted as HTML? Fixed by putting \` around it
2) The last list for fixing compiling to bitnami gets its numbers changed. By moving to an unordered list I hope to "hide" that