### PR TITLE
UPDATE prologue regex dependency

### DIFF
--- a/prologue.nimble
+++ b/prologue.nimble
@@ -9,7 +9,7 @@ srcDir        = "src"
 
 # Dependencies
 requires "nim >= 1.6.0"
-requires "regex >= 0.16.2"
+requires "regex >= 0.20.0"
 requires "nimcrypto >= 0.5.4"
 requires "cookiejar >= 0.2.0"
 requires "httpx >= 0.2.0"


### PR DESCRIPTION
Older regex versions have a bug that makes it impossible to compile prologue projects:
> .nimble/pkgs/regex-0.19.0/regex.nim(856, 18) Error: Exception can raise an unlisted exception: Exception

This is fixed with 0.20.0