### PR TITLE
fix content type without charset no semicolon

### DIFF
--- a/src/prologue/core/context.nim
+++ b/src/prologue/core/context.nim
@@ -535,7 +535,10 @@ proc staticFileResponse*(
     ctx.response.headers = headers.get
 
   if mimetype.len != 0:
-    ctx.response.setHeader("Content-Type", fmt"{mimetype}; {charset}")
+    if charset.len != 0:
+      ctx.response.setHeader("Content-Type", fmt"{mimetype}; {charset}")
+    else:
+      ctx.response.setHeader("Content-Type", mimetype)
 
   ctx.response.setHeader("Last-Modified", $lastModified)
   ctx.response.setHeader("Etag", etag)


### PR DESCRIPTION
As discussed with xflywind in chat `#nim-webdev:matrix.org` ,  
a fix that omits the semicolon in `Content-Type` , 
if mimetype is present, but no charset is given.