### PR TITLE
Allow Sessions to support secure cookie settings

### DIFF
--- a/src/prologue/middlewares/sessions/memorysession.nim
+++ b/src/prologue/middlewares/sessions/memorysession.nim
@@ -21,7 +21,8 @@ proc sessionMiddleware*(
   path = "",
   domain = "",
   sameSite = Lax,
-  httpOnly = false
+  httpOnly = false,
+  secure = false
 ): HandlerAsync =
 
   var memorySessionTable = newTable[string, Session]()
@@ -38,7 +39,7 @@ proc sessionMiddleware*(
       data = urlsafeBase64Encode(randomBytesSeq(16))
       ctx.setCookie(sessionName, data, 
               maxAge = some(maxAge), path = path, domain = domain, 
-              sameSite = sameSite, httpOnly = httpOnly)
+              sameSite = sameSite, httpOnly = httpOnly, secure = secure)
       memorySessionTable[data] = ctx.session
 
     await switch(ctx)

--- a/src/prologue/middlewares/sessions/redissession.nim
+++ b/src/prologue/middlewares/sessions/redissession.nim
@@ -30,7 +30,8 @@ proc sessionMiddleware*(
   path = "",
   domain = "",
   sameSite = Lax,
-  httpOnly = false
+  httpOnly = false,
+  secure = false
 ): HandlerAsync =
 
   var redisClient = waitFor openAsync()
@@ -53,7 +54,7 @@ proc sessionMiddleware*(
       data = genUid()
       ctx.setCookie(sessionName, data, 
               maxAge = some(maxAge), path = path, domain = domain, 
-              sameSite = sameSite, httpOnly = httpOnly)
+              sameSite = sameSite, httpOnly = httpOnly, secure = secure)
 
     await switch(ctx)
 

--- a/src/prologue/middlewares/sessions/signedcookiesession.nim
+++ b/src/prologue/middlewares/sessions/signedcookiesession.nim
@@ -24,7 +24,8 @@ proc sessionMiddleware*(
   path = "",
   domain = "",
   sameSite = Lax,
-  httpOnly = false
+  httpOnly = false,
+  secure = false
 ): HandlerAsync =
 
   var secretKey = settings["prologue"].getOrDefault("secretKey").getStr
@@ -69,4 +70,4 @@ proc sessionMiddleware*(
     if ctx.session.modified:
       ctx.setCookie(sessionName, signer.sign(dumps(ctx.session)), 
                     maxAge = some(maxAge), path = path, domain = domain, 
-                    sameSite = sameSite, httpOnly = httpOnly)
+                    sameSite = sameSite, httpOnly = httpOnly, secure = secure)


### PR DESCRIPTION
I have built a small web-app based on Prologue that is integrated with a legacy site in an iframe. The iframe "drops" the sessions since the sameSite is set to Lax, and if it's set to None, the secure flag must be set as well, which is impossible without exposing that parameter to the session init caller.

Running with these changes and an associated modification to the cookiejar package allows the web application to function as expected within an iframe.