### PR TITLE
Fixed unexpected behavior when double leading slash on route

### DIFF
--- a/src/prologue/core/route.nim
+++ b/src/prologue/core/route.nim
@@ -130,15 +130,8 @@ template isInvalidPath(path: string): bool =
 func ensureCorrectRoute(
   path: string
 ): string {.raises: [].} =
-  ## Strips trailing slashes, and guarantees leading slashes.
-  result = path
-
-  if result.len == 1 and result[0] == '/':
-    return
-  if result[^1] == pathSeparator: # patterns should not end in a separator, it's redundant
-    result = result[0 .. ^2]
-  if not (result[0] == '/'): # ensure each pattern is relative to root
-    result.insert("/")
+  ## Strips trailing slashes, and guarantees one leading slash.
+  pathSeparator & path.strip(chars={pathSeparator})
 
 func emptyBnodeSequence(
   bnodeSeq: seq[BasePatternNode]


### PR DESCRIPTION
Hello,

Prologue doesn't accept ``//a/b/c`` nor warns about it being invalid.
So, this rewrite trims all the slashes on the ends, and then adds one onto the front.
It also seems to pass all the tests from ``nimble tests``.

Thank you!