### PR TITLE
Allow custom socket listener

### DIFF
--- a/prologue.nimble
+++ b/prologue.nimble
@@ -12,7 +12,7 @@ requires "nim >= 1.6.0"
 requires "regex >= 0.20.0"
 requires "nimcrypto >= 0.5.4"
 requires "cookiejar >= 0.2.0"
-requires "httpx >= 0.3.4"
+requires "httpx >= 0.3.7"
 requires "logue >= 0.2.0"
 
 

--- a/src/prologue/core/application.nim
+++ b/src/prologue/core/application.nim
@@ -555,6 +555,8 @@ proc runAsync*(app: Prologue) {.inline, async.} =
 
 
 when isMainModule:
+  import net
+
   proc hello(ctx: Context) {.async.} =
     logging.debug "hello"
     resp "<h1>Hello, Prologue!</h1>"
@@ -579,7 +581,11 @@ when isMainModule:
     logging.debug "doLogin"
     resp redirect("/hello/Nim")
 
-  let settings = newSettings(appName = "Prologue", debug = true)
+  let socket = newSocket()
+  socket.bindAddr(Port(8080), "0.0.0.0")
+  socket.setSockOpt(OptReuseAddr, true)
+  socket.listen()
+  let settings = newSettings(appName = "Prologue", debug = true, listener = socket)
   var app = newApp(settings = settings)
 
   app.addRoute("/", home, HttpGet)

--- a/src/prologue/core/beast/server.nim
+++ b/src/prologue/core/beast/server.nim
@@ -27,7 +27,7 @@ proc execStartupEvent*(app: Prologue) =
 proc getSettings(app: Prologue): httpx.Settings =
   result = httpx.initSettings(app.gScope.settings.port, app.gScope.settings.address,
                 app.gScope.settings["prologue"].getOrDefault("numThreads").getInt(0),
-                app.startupClosure)
+                app.startupClosure, app.gScope.settings.listener)
 
 proc serve*(app: Prologue,
             callback: proc (request: NativeRequest): Future[void] {.closure, gcsafe.},


### PR DESCRIPTION
Allow custom listener socket. This can be used to implement systemd socket activation or to configure a server over unix domain sockets.

Depends on https://github.com/ringabout/httpx/pull/31