### PR TITLE
Fix some typos in the documentation

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@ This is an example of how you can deploy a prologue web-application that was com
 
 We will look at 2 base images as starting points:
 
-2. [bitnami/mindeb](https://hub.docker.com/r/bitnami/minideb)
+2. [bitnami/minideb](https://hub.docker.com/r/bitnami/minideb)
 3. [alpine](https://hub.docker.com/_/alpine)
 
 The process is similar for both, but does contain differences, particularly in the dockerfile and commands needed to compile your project.
@@ -24,8 +24,8 @@ Alpine uses `musl`, which is much more minimalistic.
 
 Because `musl` and `glibc` are different, compiling your application to link with them also differs.
 
-### On bitnami/mindeb
-bitnami/minideb is basically a debian image, reduced to the minimum.
+### On bitnami/minideb
+bitnami/minideb is basically a Debian image, reduced to the minimum.
 
 Since it is based on debian, it uses `gnu c library` (glibc), which is the main advantage of this image. 
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,7 @@
 
 ## Benchmarking and debug
 
-If you want to benchmark `prologue` or release you programs, make sure set `settings.debug` = false.
+If you want to benchmark `prologue` or release your programs, make sure to set `settings.debug` = false.
 
 ```nim
 let

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -111,7 +111,7 @@ app.use(staticFileMiddleware("/public"))
 
 ## Redirect
 
-You can easily redirect to other URL using `redirect` function. The default HTTP code for `redirct` function is Http301. You could use Http302 to move temporarily.
+You can easily redirect to other URL using `redirect` function. The default HTTP code for `redirect` function is Http301. You could use Http302 to move temporarily.
 
 The program below redirects to `localhost:8080/home`.
 

--- a/docs/uploadfile.md
+++ b/docs/uploadfile.md
@@ -9,7 +9,7 @@
 </form>
 ```
 
-`getUploadFile` only works when using form parameters and HttpPost method. `Context` provides a helper function to `save` the uploadFile to disks. If you don't specify the name of the file, it will use the origin name from the client.
+`getUploadFile` only works when using form parameters and HttpPost method. `Context` provides a helper function to `save` the uploadFile to disks. If you don't specify the name of the file, it will use the original name from the client.
 
 ```nim
 proc upload(ctx: Context) {.async.} =

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -14,7 +14,7 @@ let
   checkInt = isInt(msg)
 
 doAssert checkInt("12") == (true, "")
-doAssert checkInt("912.6) == (false, msg)
+doAssert checkInt("912.6") == (false, msg)
 ```
 
 ## Multiple Records
@@ -34,9 +34,9 @@ var form = newFormValidation({
 let
   chk1 = form.validate({"required": "on", "accepted": "true",
       "requiredInt": "12", "minValue": "15"}.newStringTable)
-  chk2 = form.validate({"requird": "on", "time": "555",
+  chk2 = form.validate({"required": "on", "time": "555",
       "minValue": "10"}.newStringTable)
-  chk3 = form.validate({"requird": "on", "time": "555",
+  chk3 = form.validate({"required": "on", "time": "555",
       "minValue": "10"}.newStringTable, allMsgs = false)
   chk4 = form.validate({"required": "on", "accepted": "true",
   "requiredInt": "12.5", "minValue": "13"}.newStringTable, allMsgs = false)

--- a/docs/views.md
+++ b/docs/views.md
@@ -1,6 +1,6 @@
 # Views
 
-`Prologue` doesn't provide any templates engines. But we recommend [karax](https://github.com/pragmagic/karax) to you. `karax` is a powerful template engines based on DSL. It is suitable for server side rendering.
+`Prologue` doesn't provide any templates engines. But we recommend [karax](https://github.com/pragmagic/karax) to you. `karax` is a powerful template engine based on DSL. It is suitable for server side rendering.
 
 You should use `nimble install karax` or `logue extension karax` to install it.
 


### PR DESCRIPTION
I noted various typos (mainly missing letters) while reading the doc.