### PR TITLE
Fix for outdated blog example std/db_sqlite exists no more

### DIFF
--- a/examples/blog/initdb.nim
+++ b/examples/blog/initdb.nim
@@ -1,5 +1,5 @@
-import std/[db_sqlite, os, strutils, logging]
-
+import std/[os, strutils, logging]
+import db_connector/db_sqlite
 import ./consts
 
 

--- a/examples/blog/views.nim
+++ b/examples/blog/views.nim
@@ -1,4 +1,5 @@
-import std/[db_sqlite, strformat]
+import std/[strformat]
+import db_connector/db_sqlite
 
 import prologue
 import prologue/security/hasher

--- a/examples/blog/views.nim
+++ b/examples/blog/views.nim
@@ -1,4 +1,4 @@
-import std/[strformat]
+import std/strformat
 import db_connector/db_sqlite
 
 import prologue


### PR DESCRIPTION
As of the latest nim release we know that `std/db_sqlite` exists no more hence this pr will fix the issue.
I have changes `import std/db_sqlite` to `import db_connector/db_sqlite`