### PR TITLE
Content-Type header parser

### DIFF
--- a/src/prologue/core/contenttype.nim
+++ b/src/prologue/core/contenttype.nim
@@ -6,6 +6,12 @@ type
     subType*: string
     parameters*: Table[string, string]
 
+const
+  # Token characters as per RFC 7230 section 3.2.6
+  # https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
+  VALID_TOKEN_CHARACTERS = {'a'..'z', 'A'..'Z', '0'..'9',
+    '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~'}
+
 proc parseContentType*(headerValue: string): MediaType =
   ## Parses a Content-Type header according to RFC 7230, RFC 2045, and RFC 2046.
   ## Returns a MediaType object containing the main type, sub type, and parameters.
@@ -101,9 +107,7 @@ proc `$`*(mediaType: MediaType): string =
   for name, value in mediaType.parameters:
     var needsQuotes = false
     for c in value:
-      # valid token characters as per RFC 7230 section 3.2.6
-      if not (c in {'a'..'z', 'A'..'Z', '0'..'9',
-                    '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~'}):
+      if c notin VALID_TOKEN_CHARACTERS:
         needsQuotes = true
         break
 

--- a/src/prologue/core/contenttype.nim
+++ b/src/prologue/core/contenttype.nim
@@ -15,6 +15,13 @@ const
 proc parseContentType*(headerValue: string): MediaType =
   ## Parses a Content-Type header according to RFC 7230, RFC 2045, and RFC 2046.
   ## Returns a MediaType object containing the main type, sub type, and parameters.
+  runnableExamples:
+    let mediaType = parseContentType("text/plain; charset=\"utf-8\"")
+    doAssert mediaType.mainType == "text"
+    doAssert mediaType.subType == "plain"
+    doAssert mediaType.parameters.len == 1
+    doAssert mediaType.parameters["charset"] == "utf-8"
+
   result = MediaType(parameters: initTable[string, string]())
   var
     i = 0

--- a/src/prologue/core/contenttype.nim
+++ b/src/prologue/core/contenttype.nim
@@ -1,4 +1,4 @@
-import std/[strutils, tables, strformat]
+import std/[strutils, tables, strformat, sequtils]
 
 type
   MediaType* = object
@@ -105,13 +105,7 @@ proc `$`*(mediaType: MediaType): string =
   result = mediaType.mainType & "/" & mediaType.subType
 
   for name, value in mediaType.parameters:
-    var needsQuotes = false
-    for c in value:
-      if c notin VALID_TOKEN_CHARACTERS:
-        needsQuotes = true
-        break
-
-    if needsQuotes:
+    if value.anyIt(it notin VALID_TOKEN_CHARACTERS):
       result.add(&"; {name}=\"{value}\"")
     else:
       result.add(&"; {name}={value}")

--- a/src/prologue/core/contenttype.nim
+++ b/src/prologue/core/contenttype.nim
@@ -1,0 +1,113 @@
+import std/[strutils, tables, strformat]
+
+type
+  MediaType* = object
+    mainType*: string
+    subType*: string
+    parameters*: Table[string, string]
+
+proc parseContentType*(headerValue: string): MediaType =
+  ## Parses a Content-Type header according to RFC 7230, RFC 2045, and RFC 2046.
+  ## Returns a MediaType object containing the main type, sub type, and parameters.
+  result = MediaType(parameters: initTable[string, string]())
+  var
+    i = 0
+    headerLen = headerValue.len
+
+  while i < headerLen and headerValue[i] in Whitespace:
+    inc i
+
+  # media type
+  let mediaTypeStart = i
+  while i < headerLen and headerValue[i] notin {';', ' ', '\t'}:
+    inc i
+
+  let mediaType = headerValue[mediaTypeStart..<i].strip()
+  let typeParts = mediaType.split('/')
+
+  if typeParts.len != 2:
+    raise newException(ValueError, &"Invalid media type: {mediaType}")
+
+  result.mainType = typeParts[0].toLowerAscii
+  result.subType = typeParts[1].toLowerAscii
+
+  while i < headerLen and headerValue[i] in Whitespace:
+    inc i
+
+  # params
+  while i < headerLen and headerValue[i] == ';':
+    inc i
+
+    while i < headerLen and headerValue[i] in Whitespace:
+      inc i
+
+    # param name
+    let paramNameStart = i
+    while i < headerLen and headerValue[i] notin {'=', ';', ' ', '\t'}:
+      inc i
+
+    if i >= headerLen or headerValue[i] != '=':
+      # this is a malformed parameter - skip it
+      while i < headerLen and headerValue[i] != ';':
+        inc i
+      continue
+
+    let paramName = headerValue[paramNameStart..<i].strip().toLowerAscii()
+    inc i
+
+    while i < headerLen and headerValue[i] in Whitespace:
+      inc i
+
+    # param value
+    var
+      paramValue: string
+      foundClosingQuote = false
+
+    if i < headerLen and headerValue[i] == '"':
+      # quoted value
+      inc i
+      let valueStart = i
+
+      while i < headerLen:
+        if headerValue[i] == '\\' and i + 1 < headerLen and headerValue[i + 1] == '"':
+          inc i, 2
+        elif headerValue[i] == '"':
+          paramValue = headerValue[valueStart..<i]
+          inc i
+          foundClosingQuote = true
+          break
+        else:
+          inc i
+
+      if not foundClosingQuote:
+        paramValue = headerValue[valueStart..<headerLen]
+    else:
+      # unquoted value
+      let valueStart = i
+      while i < headerLen and headerValue[i] notin {';', ' ', '\t'}:
+        inc i
+
+      paramValue = headerValue[valueStart..<i]
+
+    result.parameters[paramName] = paramValue
+
+    while i < headerLen and headerValue[i] in Whitespace:
+      inc i
+
+proc `$`*(mediaType: MediaType): string =
+  ## Convert MediaType to string representation
+  result = mediaType.mainType & "/" & mediaType.subType
+
+  for name, value in mediaType.parameters:
+    var needsQuotes = false
+    for c in value:
+      # valid token characters as per RFC 7230 section 3.2.6
+      if not (c in {'a'..'z', 'A'..'Z', '0'..'9',
+                    '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~'}):
+        needsQuotes = true
+        break
+
+    if needsQuotes:
+      result.add(&"; {name}=\"{value}\"")
+    else:
+      result.add(&"; {name}={value}")

--- a/src/prologue/core/contenttype.nim
+++ b/src/prologue/core/contenttype.nim
@@ -12,6 +12,12 @@ const
   VALID_TOKEN_CHARACTERS = {'a'..'z', 'A'..'Z', '0'..'9',
     '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~'}
 
+proc skipWhitespace(headerValue: string, i: var int) =
+  ## Skips the next whitespace characters beginning from index ``i``.
+  ## This updates the param ``i``
+  while i < headerValue.len and headerValue[i] in Whitespace:
+    inc i
+
 proc parseContentType*(headerValue: string): MediaType =
   ## Parses a Content-Type header according to RFC 7230, RFC 2045, and RFC 2046.
   ## Returns a MediaType object containing the main type, sub type, and parameters.
@@ -27,8 +33,7 @@ proc parseContentType*(headerValue: string): MediaType =
     i = 0
     headerLen = headerValue.len
 
-  while i < headerLen and headerValue[i] in Whitespace:
-    inc i
+  headerValue.skipWhitespace(i)
 
   # media type
   let mediaTypeStart = i
@@ -44,15 +49,13 @@ proc parseContentType*(headerValue: string): MediaType =
   result.mainType = typeParts[0].toLowerAscii
   result.subType = typeParts[1].toLowerAscii
 
-  while i < headerLen and headerValue[i] in Whitespace:
-    inc i
+  headerValue.skipWhitespace(i)
 
   # params
   while i < headerLen and headerValue[i] == ';':
     inc i
 
-    while i < headerLen and headerValue[i] in Whitespace:
-      inc i
+    headerValue.skipWhitespace(i)
 
     # param name
     let paramNameStart = i
@@ -68,8 +71,7 @@ proc parseContentType*(headerValue: string): MediaType =
     let paramName = headerValue[paramNameStart..<i].strip().toLowerAscii()
     inc i
 
-    while i < headerLen and headerValue[i] in Whitespace:
-      inc i
+    headerValue.skipWhitespace(i)
 
     # param value
     var
@@ -103,9 +105,7 @@ proc parseContentType*(headerValue: string): MediaType =
       paramValue = headerValue[valueStart..<i]
 
     result.parameters[paramName] = paramValue
-
-    while i < headerLen and headerValue[i] in Whitespace:
-      inc i
+    headerValue.skipWhitespace(i)
 
 proc `$`*(mediaType: MediaType): string =
   ## Convert MediaType to string representation

--- a/src/prologue/core/form.nim
+++ b/src/prologue/core/form.nim
@@ -12,23 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import std/[strtabs, strutils, strformat, parseutils, tables]
 from std/uri import decodeQuery
 
 import ./httpcore/httplogue
 from ./types import FormPart, initFormPart, `[]=`
 import ./request
+import ./contenttype
 
 
 func parseFormPart*(body, contentType: string): FormPart =
   ## Parses form part of the body of the request.
   let
-    sep = contentType[contentType.rfind("boundary") + 9 .. ^1]
+    mediaType = parseContentType(contentType)
+    sep = if "boundary" in mediaType.parameters: mediaType.parameters["boundary"] else: ""
     startSep = fmt"--{sep}"
     endSep = fmt"--{sep}--"
     startPos = find(body, startSep)
     endPos = rfind(body, endSep)
+
+  # make sure we found valid boundaries
+  if startPos < 0 or endPos < 0 or startPos >= endPos:
+    return initFormPart()
+
+  let
     formData = body[startPos ..< endPos]
     formDataSeq = formData.split(startSep & "\c\L")
 
@@ -89,18 +96,19 @@ func parseFormPart*(body, contentType: string): FormPart =
 
 func parseFormParams*(request: var Request, contentType: string) =
   ## Parses get or post or query parameters.
-  if "form-urlencoded" in contentType:
+  let mediaType = parseContentType(contentType)
+
+  if mediaType.mainType == "application" and mediaType.subType == "x-www-form-urlencoded":
     request.formParams = initFormPart()
     if request.reqMethod == HttpPost:
       for (key, value) in decodeQuery(request.body):
         # formPrams and postParams for secret event
         request.formParams[key] = value
         request.postParams[key] = value
-  elif "multipart/form-data" in contentType and "boundary" in contentType:
+  elif mediaType.mainType == "multipart" and mediaType.subType == "form-data" and "boundary" in mediaType.parameters:
     request.formParams = parseFormPart(request.body, contentType)
 
   # /student?name=simon&age=sixteen
   # query -> name=simon&age=sixteen
-
   for (key, value) in decodeQuery(request.query):
     request.queryParams[key] = value

--- a/tests/unit/tunit_core/tunit_contenttype.nim
+++ b/tests/unit/tunit_core/tunit_contenttype.nim
@@ -1,0 +1,164 @@
+import ../../../src/prologue/core/contenttype
+import std/[tables, strutils, strformat]
+
+block:
+  let mediaType = parseContentType("text/plain")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 0
+
+block:
+  let mediaType = parseContentType("text/plain; charset=utf-8")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 1
+  doAssert "charset" in mediaType.parameters
+  doAssert mediaType.parameters["charset"] == "utf-8"
+
+block:
+  let mediaType = parseContentType("text/plain; charset=utf-8; format=flowed")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 2
+  doAssert "charset" in mediaType.parameters
+  doAssert "format" in mediaType.parameters
+  doAssert mediaType.parameters["charset"] == "utf-8"
+  doAssert mediaType.parameters["format"] == "flowed"
+
+block:
+  let mediaType = parseContentType("text/plain; charset=\"utf-8\"")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 1
+  doAssert "charset" in mediaType.parameters
+  doAssert mediaType.parameters["charset"] == "utf-8"
+
+block:
+  let mediaType = parseContentType("application/json; charset=\"utf 8\"")
+  doAssert mediaType.mainType == "application"
+  doAssert mediaType.subType == "json"
+  doAssert mediaType.parameters.len == 1
+  doAssert "charset" in mediaType.parameters
+  doAssert mediaType.parameters["charset"] == "utf 8"
+
+block:
+  let mediaType = parseContentType("multipart/form-data; boundary=---------------------------263701891623491983764541468")
+  doAssert mediaType.mainType == "multipart"
+  doAssert mediaType.subType == "form-data"
+  doAssert mediaType.parameters.len == 1
+  doAssert "boundary" in mediaType.parameters
+  doAssert mediaType.parameters["boundary"] == "---------------------------263701891623491983764541468"
+
+block:
+  let mediaType = parseContentType("multipart/form-data; boundary=\"simple-boundary\"")
+  doAssert mediaType.mainType == "multipart"
+  doAssert mediaType.subType == "form-data"
+  doAssert mediaType.parameters.len == 1
+  doAssert "boundary" in mediaType.parameters
+  doAssert mediaType.parameters["boundary"] == "simple-boundary"
+
+block:
+  let mediaType = parseContentType("multipart/form-data; boundary=\"boundary with spaces and-dashes\"")
+  doAssert mediaType.mainType == "multipart"
+  doAssert mediaType.subType == "form-data"
+  doAssert mediaType.parameters.len == 1
+  doAssert "boundary" in mediaType.parameters
+  doAssert mediaType.parameters["boundary"] == "boundary with spaces and-dashes"
+
+block:
+  let mediaType = parseContentType("text/plain; description=\"This is a \\\"quoted\\\" description\"")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 1
+  doAssert "description" in mediaType.parameters
+  doAssert mediaType.parameters["description"] == "This is a \\\"quoted\\\" description"
+
+block:
+  let mediaType = parseContentType("TeXt/PlAiN; ChArSeT=UTF-8")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 1
+  doAssert "charset" in mediaType.parameters
+  doAssert mediaType.parameters["charset"] == "UTF-8"
+
+block:
+  let mediaType = parseContentType("  text/plain  ;  charset=utf-8  ;  format=flowed  ")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 2
+  doAssert "charset" in mediaType.parameters
+  doAssert "format" in mediaType.parameters
+  doAssert mediaType.parameters["charset"] == "utf-8"
+  doAssert mediaType.parameters["format"] == "flowed"
+
+block:
+  let mediaType = parseContentType("text/plain; charset")
+  doAssert mediaType.mainType == "text"
+  doAssert mediaType.subType == "plain"
+  doAssert mediaType.parameters.len == 0
+
+block:
+  try:
+    discard parseContentType("text")
+    doAssert false, "Should have raised an exception"
+  except ValueError:
+    doAssert true
+
+block:
+  let mediaType = parseContentType("text/plain; charset=utf-8; format=flowed")
+  let str = $mediaType
+  doAssert str.startsWith("text/plain")
+  doAssert "; charset=utf-8" in str
+  doAssert "; format=flowed" in str
+
+block:
+  var mediaType = MediaType(
+    mainType: "multipart",
+    subType: "form-data",
+    parameters: {"boundary": "simple boundary with spaces"}.toTable
+  )
+  let str = $mediaType
+  doAssert str == "multipart/form-data; boundary=\"simple boundary with spaces\""
+
+block:
+  var mediaType = MediaType(
+    mainType: "text",
+    subType: "plain",
+    parameters: {
+      "charset": "utf-8",
+      "description": "This is a description with spaces"
+    }.toTable
+  )
+  let str = $mediaType
+  doAssert str.startsWith("text/plain")
+  doAssert "; charset=utf-8" in str
+  doAssert "; description=\"This is a description with spaces\"" in str
+
+# some real-world examples
+block:
+  let examples = [
+    "text/html; charset=UTF-8",
+    "application/json",
+    "application/x-www-form-urlencoded",
+    "multipart/form-data; boundary=something",
+    "image/jpeg",
+    "application/octet-stream",
+    "text/css; charset=utf-8",
+    "application/javascript",
+    "multipart/mixed; boundary=\"frontier\"",
+    "application/pdf",
+    "text/plain; charset=us-ascii"
+  ]
+
+  for example in examples:
+    let mediaType = parseContentType(example)
+    let roundTrip = $mediaType
+
+    let roundTripMediaType = parseContentType(roundTrip)
+    doAssert roundTripMediaType.mainType == mediaType.mainType
+    doAssert roundTripMediaType.subType == mediaType.subType
+    doAssert roundTripMediaType.parameters.len == mediaType.parameters.len
+
+    for key, value in mediaType.parameters:
+      doAssert key in roundTripMediaType.parameters
+      doAssert roundTripMediaType.parameters[key] == value

--- a/tests/unit/tunit_core/tunit_form.nim
+++ b/tests/unit/tunit_core/tunit_form.nim
@@ -1,24 +1,42 @@
 import ../../../src/prologue/core/form
 import tables, strutils
-const testmime =
-  "-----------------------------263701891623491983764541468\13\10" &
-  "Content-Disposition: form-data; name=\"howLongValid\"\13\10" &
-  "\13\10" &
-  "3600\13\10" &
-  "-----------------------------263701891623491983764541468\13\10" &
-  "Content-Disposition: form-data; name=\"upload\"; filename=\"testfile.txt\"\13\10" &
-  "Content-Type: text/plain\13\10" &
-  "\13\10" &
-  "1234\13\10" &
-  "5678\13\10" &
-  "abcd\13\10" &
-  "-----------------------------263701891623491983764541468--\13\10"
-const testfile =
-  "1234\13\10" &
-  "5678\13\10" &
-  "abcd"
-const contenttype = "multipart/form-data; boundary=---------------------------263701891623491983764541468"
-let formPart = parseFormPart(testmime, contenttype)
-doAssert formPart.data["upload"].body.len == testfile.len
-doAssert formPart.data["upload"].body == testfile
-doAssert parseInt(formPart.data["howLongValid"].body) == 3600
+
+block:
+  const testmime =
+    "-----------------------------263701891623491983764541468\13\10" &
+    "Content-Disposition: form-data; name=\"howLongValid\"\13\10" &
+    "\13\10" &
+    "3600\13\10" &
+    "-----------------------------263701891623491983764541468\13\10" &
+    "Content-Disposition: form-data; name=\"upload\"; filename=\"testfile.txt\"\13\10" &
+    "Content-Type: text/plain\13\10" &
+    "\13\10" &
+    "1234\13\10" &
+    "5678\13\10" &
+    "abcd\13\10" &
+    "-----------------------------263701891623491983764541468--\13\10"
+  const testfile =
+    "1234\13\10" &
+    "5678\13\10" &
+    "abcd"
+  const contenttype = "multipart/form-data; boundary=---------------------------263701891623491983764541468"
+  let formPart = parseFormPart(testmime, contenttype)
+  doAssert formPart.data["upload"].body.len == testfile.len
+  doAssert formPart.data["upload"].body == testfile
+  doAssert parseInt(formPart.data["howLongValid"].body) == 3600
+
+block:
+  # check that quoted boundary values work
+  const testfile =
+    "data"
+  const testmime =
+    "--boundary\13\10" &
+    "Content-Disposition: form-data; name=\"upload\"\13\10" &
+    "\13\10" &
+    testfile &
+    "\13\10" &
+    "--boundary--\13\10"
+  const contenttype = "multipart/form-data; boundary=\"boundary\""
+  let formPart = parseFormPart(testmime, contenttype)
+  doAssert formPart.data["upload"].body.len == testfile.len
+  doAssert formPart.data["upload"].body == testfile


### PR DESCRIPTION
This fixes #257.

Added a spec-compliant (as far as I can tell) header parser for the Content-Type header, specifically in regards to the `boundary` param. Also added some tests for the new parser and `form.nim`.